### PR TITLE
API routes for tag-routes

### DIFF
--- a/routes/api/category-routes.js
+++ b/routes/api/category-routes.js
@@ -22,7 +22,7 @@ router.get('/:id', async (req, res) => {
       include: [{ model: Product }],
     });
     if (!categoryData) {
-      res.status(404).json({ message: 'No category found with that that id.'});
+      res.status(404).json({ message: 'No category found with that that id.' });
       return;
     }
     res.status(200).json(categoryData);
@@ -48,7 +48,7 @@ router.put('/:id', async (req, res) => {
       where: { id: req.params.id },
     });
     if (!categoryData[0]) {
-      res.status(404).json({ message: 'No category found with that id.'});
+      res.status(404).json({ message: 'No category found with that id.' });
       return;
     }
     res.status(200).json(categoryData);
@@ -64,7 +64,7 @@ router.delete('/:id', async (req, res) => {
       where: { id: req.params.id },
     });
     if (!categoryData) {
-      res.status(404).json({ message: 'No category found with that id.'});
+      res.status(404).json({ message: 'No category found with that id.' });
       return;
     }
     res.status(200).json(categoryData);

--- a/routes/api/product-routes.js
+++ b/routes/api/product-routes.js
@@ -116,10 +116,10 @@ router.delete('/:id', async (req, res) => {
       where: { id: req.params.id }
     });
     if (!productData) {
-      res.status.apply(404).json({ message: 'No product found with this id.'});
+      res.status.apply(404).json({ message: 'No product found with this id.' });
       return;
     }
-    res.status(200).json({ message: 'Product deleted successfully.'});
+    res.status(200).json({ message: 'Product deleted successfully.' });
   } catch (err) {
     res.status(500).json(err);
   }

--- a/routes/api/tag-routes.js
+++ b/routes/api/tag-routes.js
@@ -3,26 +3,78 @@ const { Tag, Product, ProductTag } = require('../../models');
 
 // The `/api/tags` endpoint
 
-router.get('/', (req, res) => {
-  // find all tags
-  // be sure to include its associated Product data
+// Find all tags
+router.get('/', async (req, res) => {
+  try {
+    const tagData = await Tag.findAll({
+      include: [{ model: Product }]
+    });
+    res.status(200).json(tagsData);
+  } catch (err) {
+    res.status(500).json(err);
+  }
 });
 
-router.get('/:id', (req, res) => {
-  // find a single tag by its `id`
-  // be sure to include its associated Product data
+// Find a single tag by its id
+router.get('/:id', async (req, res) => {
+  try {
+    const tagData = await Tag.findByPk(req.params.id, {
+      include: [{ model: Product }]
+    });
+    if (!tagData) {
+      res.status(404).json({ message: 'No tag found with this id.'});
+      return;
+    }
+    res.status(200).json(tagData);
+  } catch (err) {
+    res.status(500).json(err);
+  }
 });
 
-router.post('/', (req, res) => {
-  // create a new tag
+// Create a new tag
+router.post('/', async (req, res) => {
+  try {
+    const tagData = await Tag.create(req.body);
+    res.status(200).json(tagData);
+  } catch (err) {
+    res.status(500).json(err);
+  }
 });
 
-router.put('/:id', (req, res) => {
-  // update a tag's name by its `id` value
+// Update a tag's name by it's id value
+router.put('/:id', async (req, res) => {
+  try {
+    const tagData = await Tag.update(req.body, {
+      where: {
+        id: req.params.id,
+      },
+    });
+    if (!tagData[0]) {
+      res.status(404).json({ message: 'No tag found with this id.' });
+      return;
+    }
+    res.status(200).json(tagData);
+  } catch (err) {
+    res.status(500).json(err);
+  }
 });
 
-router.delete('/:id', (req, res) => {
-  // delete on tag by its `id` value
+// Delete a tag by it's id value
+router.delete('/:id', async (req, res) => {
+  try {
+    const tagData = await Tag.destroy({
+      where: {
+        id: req.params.id,
+      },
+    });
+    if (!tagData) {
+      res.status(404).json({ message: 'No tag found with this id.' });
+      return;
+    }
+    res.status(200).json({ message: 'Tag successfully deleted.' });
+  } catch (err) {
+    res.status(500).json(err);
+  }
 });
 
 module.exports = router;


### PR DESCRIPTION
Updated the tag-routes.js with API routes that do the following:

-Find all tags
-Find a single tag by it's id
-Create a new tag
-Update a tag's name by it's id value
-Delete a tag by it's id value


-Fixed some small typos in the other routes folder